### PR TITLE
Bug fix: swap with temporary is not allowed

### DIFF
--- a/code/BufferedMessage.hpp
+++ b/code/BufferedMessage.hpp
@@ -86,7 +86,7 @@ namespace http {
          */
         virtual void reset_buffers ()
         {
-            myBody.swap(std::string()), Base::reset_buffers();
+            std::string().swap(myBody), Base::reset_buffers();
         }
     };
 

--- a/code/Message.cpp
+++ b/code/Message.cpp
@@ -138,8 +138,7 @@ namespace http {
 
     void Message::reset_buffers ()
     {
-        std::map<std::string,std::string> empty;
-        myHeaders.swap(empty);
+        std::map<std::string,std::string>().swap(myHeaders);
     }
 
     std::size_t Message::feed ( const void * data, ::size_t size )

--- a/code/Request.cpp
+++ b/code/Request.cpp
@@ -52,8 +52,7 @@ namespace http {
 
     void Request::reset_buffers ()
     {
-        std::string empty;
-        myUrl.swap(empty), Message::reset_buffers();
+        std::string().swap(myUrl), Message::reset_buffers();
     }
 
     const Method Request::method () const


### PR DESCRIPTION
This is a valid fix for the issue raised by a-kulbei in https://github.com/a-kulbei/httpxx/commit/46f1372582ab18fdeb1fca11479207fb77c11062 (swapping with a temporary is not allowed).

The fix suggested by a-kulbei is not valid since clearing a string does not deallocate memory buffers (which defeats the purpose of the reset_buffers method all together, one can use clear if we only want to empty the buffer).