### PR TITLE
Changes in http-parser submodule setup.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "libs/http-parser"]
+[submodule "http-parser"]
 	path = httpxx/http-parser
-url=git://github.com/joyent/http-parser.git
+url=https://github.com/joyent/http-parser.git


### PR DESCRIPTION
Use https instead of git as the URL scheme, better for machines behind
restrictive firewalls.
Module renamed from libs/http-parser to http-parser.

After pulling you have to do "git submodule sync" to make the changes
effective.