### PR TITLE
Add UserBufferedMessage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 /test/http-extract-response-body
 /test/http-extract-response-header
 /test/pipelined-headers
+/test/userbufferedmessage

--- a/httpxx/CMakeLists.txt
+++ b/httpxx/CMakeLists.txt
@@ -19,6 +19,7 @@ install(FILES ${http-parser_headers} DESTINATION include/httpxx/http-parser
 
 set(headers
   BufferedMessage.hpp
+  UserBufferedMessage.hpp
   Error.hpp
   Flags.hpp
   icompare.hpp

--- a/httpxx/UserBufferedMessage.hpp
+++ b/httpxx/UserBufferedMessage.hpp
@@ -1,5 +1,5 @@
-#ifndef _http_UserUserBufferedMessage_hpp__
-#define _http_UserUserBufferedMessage_hpp__
+#ifndef _http_UserBufferedMessage_hpp__
+#define _http_UserBufferedMessage_hpp__
 
 // Copyright(c) Andre Caron <andre.l.caron@gmail.com>, 2011-2012
 //
@@ -18,13 +18,13 @@ namespace http {
      * @brief Default strategy for handling message bodies: buffer them.
      * @tparam Message base class, must be @c Request or @c Response.
      */
-    template<class Base, class BufferType>
-    class UserBufferedMessage :
-        public Base
+    template<class Base,class T>
+    class UserBufferedMessage
+    : public Base
     {
         /* nested types. */
     private:
-        typedef UserBufferedMessage<Base, BufferType> Self;
+      typedef UserBufferedMessage<Base, T> Self;
 
         /* class methods. */
     private:
@@ -42,57 +42,39 @@ namespace http {
 
         /* construction. */
     public:
-        UserBufferedMessage ()
-            : Base(&Self::extra_configuration)
+        UserBufferedMessage (T &userbuff)
+	  : Base(&Self::extra_configuration), myBody(userbuff)
         {
         }
 
         /* data. */
     private:
-        std::string myBody;
-
-        /* methods. */
-    public:
-        /*!
-         * @brief Obtain the buffered message body.
-         */
-        const std::string& body () const
-        {
-            return (myBody);
-        }
-
-        /*!
-         * @brief Clear the body contents after processing them.
-         *
-         * This method can be used between calls to @c feed() once @c
-         * headers_complete() returns @c true, allowing you to process the
-         * body in chunks at your convenience.
-         */
-        void clear_body ()
-        {
-            myBody.clear();
-        }
-
-        /*!
-         * @brief Empty all message content, but keep allocated buffers.
-         */
-        virtual void clear ()
-        {
-            myBody.clear(), Base::clear();
-        }
-
-        /*!
-         * @brief Release memory owned by all internal buffers.
-         */
-        virtual void reset_buffers ()
-        {
-            std::string().swap(myBody), Base::reset_buffers();
-        }
+        T &myBody;
     };
 
-    typedef UserBufferedMessage<Request, class BufferType> UserBufferedRequest;
-    typedef UserBufferedMessage<Response, class BufferType> UserBufferedResponse;
+    template<class T>
+    class UserBufferedRequest : public UserBufferedMessage<Request, T>
+    {
+    public:
+      UserBufferedRequest(T &userbuf)
+        : UserBufferedMessage<Request, T>(userbuf)
+      {
+      }
+    private:
+      UserBufferedRequest() {}
+    };
 
+    template<class T>
+    class UserBufferedResponse : public UserBufferedMessage<Response, T>
+    {
+    public:
+      UserBufferedResponse(T &userbuf)
+        : UserBufferedMessage<Response, T>(userbuf)
+      {
+      }
+    private:
+      UserBufferedResponse() {}
+    };
 }
 
-#endif /* _http_UserUserBufferedMessage_hpp__ */
+#endif /* _http_UserBufferedMessage_hpp__ */

--- a/httpxx/UserBufferedMessage.hpp
+++ b/httpxx/UserBufferedMessage.hpp
@@ -1,0 +1,98 @@
+#ifndef _http_UserUserBufferedMessage_hpp__
+#define _http_UserUserBufferedMessage_hpp__
+
+// Copyright(c) Andre Caron <andre.l.caron@gmail.com>, 2011-2012
+//
+// This document is covered by the an Open Source Initiative approved license. A
+// copy of the license should have been provided alongside this software package
+// (see "LICENSE.txt"). If not, terms of the license are available online at
+// "http://www.opensource.org/licenses/mit".
+
+#include <string>
+#include "Request.hpp"
+#include "Response.hpp"
+
+namespace http {
+
+    /*!
+     * @brief Default strategy for handling message bodies: buffer them.
+     * @tparam Message base class, must be @c Request or @c Response.
+     */
+    template<class Base, class BufferType>
+    class UserBufferedMessage :
+        public Base
+    {
+        /* nested types. */
+    private:
+        typedef UserBufferedMessage<Base, BufferType> Self;
+
+        /* class methods. */
+    private:
+        static int on_body
+            ( ::http_parser * parser, const char * data, size_t size )
+        {
+            static_cast<Self*>(parser->data)->myBody.append(data, size);
+            return (0);
+        }
+
+        static void extra_configuration ( ::http_parser_settings& settings )
+        {
+            settings.on_body = &Self::on_body;
+        }
+
+        /* construction. */
+    public:
+        UserBufferedMessage ()
+            : Base(&Self::extra_configuration)
+        {
+        }
+
+        /* data. */
+    private:
+        std::string myBody;
+
+        /* methods. */
+    public:
+        /*!
+         * @brief Obtain the buffered message body.
+         */
+        const std::string& body () const
+        {
+            return (myBody);
+        }
+
+        /*!
+         * @brief Clear the body contents after processing them.
+         *
+         * This method can be used between calls to @c feed() once @c
+         * headers_complete() returns @c true, allowing you to process the
+         * body in chunks at your convenience.
+         */
+        void clear_body ()
+        {
+            myBody.clear();
+        }
+
+        /*!
+         * @brief Empty all message content, but keep allocated buffers.
+         */
+        virtual void clear ()
+        {
+            myBody.clear(), Base::clear();
+        }
+
+        /*!
+         * @brief Release memory owned by all internal buffers.
+         */
+        virtual void reset_buffers ()
+        {
+            std::string().swap(myBody), Base::reset_buffers();
+        }
+    };
+
+    typedef UserBufferedMessage<Request, class BufferType> UserBufferedRequest;
+    typedef UserBufferedMessage<Response, class BufferType> UserBufferedResponse;
+
+}
+
+#endif /* _http_UserUserBufferedMessage_hpp__ */

--- a/httpxx/UserBufferedMessage.hpp
+++ b/httpxx/UserBufferedMessage.hpp
@@ -15,8 +15,9 @@
 namespace http {
 
     /*!
-     * @brief Default strategy for handling message bodies: buffer them.
-     * @tparam Message base class, must be @c Request or @c Response.
+     * @brief Using user specified storage for body to avoid memory copy.
+     * @tparam Base Message base class, must be @c Request or @c Response.
+     * @tparam T Type of storage which supports append(const char*, size_t).
      */
     template<class Base,class T>
     class UserBufferedMessage

--- a/httpxx/http.hpp
+++ b/httpxx/http.hpp
@@ -9,6 +9,7 @@
 // "http://www.opensource.org/licenses/mit".
 
 #include "BufferedMessage.hpp"
+#include "UserBufferedMessage.hpp"
 #include "Error.hpp"
 #include "Flags.hpp"
 #include "icompare.hpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_test_program(http-extract-response-header)
 add_test_program(http-extract-request-body)
 add_test_program(http-extract-response-body)
 add_test_program(pipelined-headers)
+add_test_program(userbufferedmessage)
 
 # Test cases.
 set(test-data ${CMAKE_CURRENT_SOURCE_DIR}/data)
@@ -41,3 +42,5 @@ set_tests_properties(minimalist-test-3
   PROPERTIES PASS_REGULAR_EXPRESSION "Hello, world!")
 
 add_test(pipelined-headers "${pipelined-headers}")
+
+add_test(userbufferedmessage "${userbufferedmessage}")

--- a/test/userbufferedmessage.cpp
+++ b/test/userbufferedmessage.cpp
@@ -1,0 +1,85 @@
+#include <cassert>
+#include <cstring>
+#include <string>
+#include <httpxx/UserBufferedMessage.hpp>
+#include <iostream>
+
+static const char *req1 =
+  "POST /index.html HTTP/1.1\r\n"
+  "Host: www.example.com\r\n"
+  "Content-Length: 13\r\n"
+  "\r\n"
+  "Hello, world!\r\n";
+
+static size_t req1len = strlen(req1);
+
+static const char *req2 =
+  "POST /index.html HTTP/1.1\r\n"
+  "Host: www.example.com\r\n"
+  "\r\n";
+
+static size_t req2len = strlen(req2);
+
+static const char *resp1 =
+  "HTTP/1.1 200 OK\r\n"
+  "Content-Type: text/plain\r\n"
+  "Content-Length: 13\r\n"
+  "\r\n"
+  "Hello, world!";
+
+static size_t resp1len = strlen(resp1);
+
+static const char *resp2 =
+  "HTTP/1.1 200 OK\r\n"
+  "\r\n";
+
+static size_t resp2len = strlen(resp2);
+
+static void test_req(const char *data,
+		     size_t datalen,
+		     const char *content) {
+  std::string str;
+  http::UserBufferedRequest<std::string> parser(str);
+
+  int used = 0;
+  while (used < datalen) {
+    used += parser.feed(data + used, datalen - used);
+  }
+  parser.feed((void*)NULL, 0);
+  assert(used == datalen);
+  assert(parser.headers_complete());
+  assert(parser.complete());
+  if (content)
+    assert(str == content);
+  else
+    assert(str.length() == 0);
+}
+
+static void test_resp(const char *data,
+		      size_t datalen,
+		      const char *content) {
+  std::string str;
+  http::UserBufferedResponse<std::string> parser(str);
+  int used = 0;
+  while (used < datalen) {
+    used += parser.feed(data + used, datalen - used);
+  }
+  parser.feed((void*)NULL, 0);
+  assert(used == datalen);
+  assert(parser.headers_complete());
+  assert(parser.complete());
+  if (content)
+    assert(str == content);
+  else
+    assert(str.length() == 0);
+}
+
+int main() {
+  test_req(req1, req1len, "Hello, world!");
+  test_req(req2, req2len, NULL);
+
+  test_resp(resp1, resp1len, "Hello, world!");
+  test_resp(resp2, resp2len, NULL);
+
+  return 0;
+}


### PR DESCRIPTION
Using user specified storage for message body to avoid memory copy.
If the body is big, memory copy matters.